### PR TITLE
improving RWD of FeatureBoxes component

### DIFF
--- a/src/components/common/FeatureBox/FeatureBox.module.scss
+++ b/src/components/common/FeatureBox/FeatureBox.module.scss
@@ -4,6 +4,7 @@
   border: 1px solid $feature-box-border-color;
   text-align: center;
   margin-top: 40px;
+  height: 150px;
 
   .iconWrapper {
     height: 60px;

--- a/src/components/features/FeatureBoxes/FeatureBoxes.js
+++ b/src/components/features/FeatureBoxes/FeatureBoxes.js
@@ -15,7 +15,7 @@ const FeatureBoxes = () => (
   <div className={styles.root}>
     <div className='container'>
       <div className='row'>
-        <div className='col'>
+        <div className='col-6 col-lg-3'>
           <a href='#'>
             <FeatureBox icon={faTruck}>
               <h5>Free shipping</h5>
@@ -23,7 +23,7 @@ const FeatureBoxes = () => (
             </FeatureBox>
           </a>
         </div>
-        <div className='col'>
+        <div className='col-6 col-lg-3'>
           <a href='#'>
             <FeatureBox icon={faHeadphones}>
               <h5>24/7 customer</h5>
@@ -31,7 +31,7 @@ const FeatureBoxes = () => (
             </FeatureBox>
           </a>
         </div>
-        <div className='col'>
+        <div className='col-6 col-lg-3 mt-2 mt-lg-0'>
           <a href='#'>
             <FeatureBox icon={faReplyAll}>
               <h5>Money back</h5>
@@ -39,7 +39,7 @@ const FeatureBoxes = () => (
             </FeatureBox>
           </a>
         </div>
-        <div className='col'>
+        <div className='col-6 col-lg-3 mt-2 mt-lg-0'>
           <a href='#'>
             <FeatureBox icon={faBullhorn}>
               <h5>Member discount</h5>


### PR DESCRIPTION
PROBLEM:
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 

Ten task dotyczy kart korzyści ("Free shipping", etc.).

Klient chce w trybach tablet i mobile mieć je w 2 rzędach, po 2 elementy w każdym, ale elementy w jednym rzędzie (obok siebie) nie powinny się różnić wysokością.

SOLUTION:
Znormalizowałem wysokość komponentu FeatureBox.
Wykorzystałem klasy bootstrapowe do poprawy RWD dla komponentu FeatureBoxes.
