### PR TITLE
WDP240601-37

### DIFF
--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -82,6 +82,9 @@
   }
   &:hover .price > * {
     background-color: $product-box-price-hover-bg-color;
+    &.oldPrice {
+      background-color: $white;
+    }
   }
 }
 
@@ -99,6 +102,5 @@
     text-decoration: line-through;
     text-decoration-color: $primary;
     text-decoration-thickness: 2px;
-    
   }
 }

--- a/src/components/common/ProductBox/ProductBox.module.scss
+++ b/src/components/common/ProductBox/ProductBox.module.scss
@@ -83,7 +83,7 @@
   &:hover .price > * {
     background-color: $product-box-price-hover-bg-color;
     &.oldPrice {
-      background-color: $white;
+      background-color: $product-box-bg-color;
     }
   }
 }
@@ -95,7 +95,7 @@
 .price {
   display: flex;
 
-  .oldPrice{
+  .oldPrice {
     font-size: 16px;
     color: $dark-grey;
     margin: auto 5px;


### PR DESCRIPTION
PROBLEM:
Teraz hover na productBox powoduje, że oldPrice staje się słabo czytelna.
SOLUTION:
zmodyfikowałem style, żeby wykluczyć zmianę background-color w przypadku hover dla elementu z klasą oldPrice.
